### PR TITLE
Update webpack.config.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,14 +10,16 @@ module.exports = {
         filename: 'bundle.js'
     },
     module: {
-        loaders: [
+        rules: [
             {
-                test: /.js$/,
-                loader: 'babel-loader',
+                test: /\.js$/,
                 include: path.join(__dirname, 'app'),
                 exclude: /node_modules/,
-                query: {
-                    presets: ['es2015', 'react']
+                use: {
+                    loader: 'babel-loader',
+                    options: {
+                        presets: ['es2015', 'react']
+                    }
                 }
             }
         ]


### PR DESCRIPTION
When starting "npm run start:dev:client", webpack-dev-server throws this error: 
｢wds｣: Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration.module has an unknown property 'loaders'.
Changed 'loaders' to 'rules' and syntax of 'rules' options.